### PR TITLE
python-caja: remove dependency on python-mate

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -15,7 +15,6 @@ AC_SUBST(ACLOCAL_AMFLAGS, "-I m4 -I .")
 CAJA_REQUIRED=1.1.0
 PYGTK_REQUIRED=2.8.0
 PYGOBJECT_REQUIRED=2.16.0
-MATE_PYTHON_REQUIRED=1.1.0
 
 AC_PROG_CC
 AC_DISABLE_STATIC
@@ -44,7 +43,6 @@ AM_CHECK_PYTHON_LIBS(,[AC_MSG_ERROR(could not find Python lib)])
 
 PKG_CHECK_MODULES(CAJA_PYTHON, [pygtk-2.0 >= $PYGTK_REQUIRED
                                    pygobject-2.0 >= $PYGOBJECT_REQUIRED
-                                   mate-python-2.0 >= $MATE_PYTHON_REQUIRED
                                    libcaja-extension >= $CAJA_REQUIRED])
 
 AC_MSG_CHECKING(for pygtk defs)


### PR DESCRIPTION
builds now
