### PR TITLE
add Refresh Folder example

### DIFF
--- a/examples/refresh-folder.py
+++ b/examples/refresh-folder.py
@@ -7,12 +7,12 @@ class RefreshFolderExtension(Caja.MenuProvider, GObject.GObject):
     def __init__(self):
         pass
         
-    def menu_background_activate_cb(self, menu, file): 
+    def menu_background_activate_cb(self, menu):
         os.system("xte 'keydown F5' 'keyup F5'")
        
     def get_background_items(self, window, file):
         item = Caja.MenuItem(name='CajaPython::refreshfolder_item',
                              label='Refresh',
                              tip='Reload current folder')
-        item.connect('activate', self.menu_background_activate_cb, file)
+        item.connect('activate', self.menu_background_activate_cb)
         return item,

--- a/examples/refresh-folder.py
+++ b/examples/refresh-folder.py
@@ -1,0 +1,18 @@
+import os
+
+from gi.repository import Caja, GObject
+
+
+class RefreshFolderExtension(Caja.MenuProvider, GObject.GObject):
+    def __init__(self):
+        pass
+        
+    def menu_background_activate_cb(self, menu, file): 
+        os.system("xte 'keydown F5' 'keyup F5'")
+       
+    def get_background_items(self, window, file):
+        item = Caja.MenuItem(name='CajaPython::refreshfolder_item',
+                             label='Refresh',
+                             tip='Reload current folder')
+        item.connect('activate', self.menu_background_activate_cb, file)
+        return item,


### PR DESCRIPTION
I made this simple extension for ex-Windows users who addicted to 'Refresh' button on the desktop and in the Explorer file manager. It is a port of 'nautilus-refresh' extension for Nautilus created by Dr. Amr Osman. It simply adds an item in Caja context menu that reloads the current opened folder. The point is that it is in the context menu, not the button on toolbar or a shortcut. Some of ex-Windows users are strange, they like to right-click on the desktop and press `Refresh` from time to time:)

The extension depends on `xautomation` package. It simulates pressing F5 button by executing a command `xte 'keydown F5' 'keyup F5'`.
It looks like a hack, but I have not found a better way to perform a reload. Seems that `Caja` and `window` objects don't have a method for this action. Dr. Amr Osman's extension had been simaluting Ctrl+R key combination. If you point me to the more convenient way to make a reload, I fix it.

I'd be happy if you include this extension in Caja disabled by default, so addicted people like me could easily enable it :)

Tested in MATE 1.14.1 GTK3, Ubuntu MATE 16.10 daily build.
