### PR TITLE
Added gi.require_version()

### DIFF
--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -206,7 +206,7 @@ caja_python_init_python (void)
 	debug("import caja");
 	gi = PyImport_ImportModule ("gi");
 	if (!gi) {
-		g_critical ("can't find gi");
+		PyErr_Print();
 		return FALSE;
 	}
 

--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -157,7 +157,7 @@ caja_python_load_dir (GTypeModule *module,
 static gboolean
 caja_python_init_python (void)
 {
-	PyObject *caja;
+	PyObject *gi, *require_version, *args, *caja;
 	GModule *libpython;
 	char *argv[] = { "caja", NULL };
 
@@ -204,6 +204,19 @@ caja_python_init_python (void)
 	/* import caja */
 	g_setenv("INSIDE_CAJA_PYTHON", "", FALSE);
 	debug("import caja");
+	gi = PyImport_ImportModule ("gi");
+	if (!gi) {
+		g_critical ("can't find gi");
+		return FALSE;
+	}
+
+	require_version = PyObject_GetAttrString (gi, (char *) "require_version");
+	args = PyTuple_Pack (2, PyUnicode_FromString ("Caja"),
+	PyUnicode_FromString ("2.0"));
+	PyObject_CallObject (require_version, args);
+	Py_DECREF (require_version);
+	Py_DECREF (args);
+	Py_DECREF (gi);
 	caja = PyImport_ImportModule("gi.repository.Caja");
 	if (!caja)
 	{


### PR DESCRIPTION
taken from:
https://github.com/linuxmint/nemo-extensions/commit/67cc631

This fixes warnings like this in .xsession-errors
```
sys:1: PyGIWarning: Caja was imported without specifying a version first.
Use gi.require_version('Caja', '2.0') before import to ensure that the right version gets loaded.
```
if a python extension is used, ie. caja-terminal
https://github.com/yselkowitz/caja-terminal
