### PR TITLE
Python 3 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,9 +41,11 @@ dnl **************************************************
 AM_PATH_PYTHON([2.7])
 PKG_CHECK_MODULES([PYTHON], [python-${PYTHON_VERSION}])
 PYTHON_LIB_LOC="`pkg-config python-${PYTHON_VERSION} --variable=libdir`"
+PYTHON_ABIFLAGS=`$PYTHON -c 'import sys; exec("try: print (sys.abiflags)\nexcept: pass")'`
 AC_SUBST(PYTHON_LIBS)
 AC_SUBST(PYTHON_CFLAGS)
 AC_SUBST(PYTHON_LIB_LOC)
+AC_SUBST(PYTHON_ABIFLAGS)
 
 PYGOBJECT_MAJOR_VERSION=3
 PYGOBJECT_MINOR_VERSION=0

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ AC_DEFINE_UNQUOTED(PYGOBJECT_MINOR_VERSION,[$PYGOBJECT_MINOR_VERSION], [PyGObjec
 AC_DEFINE_UNQUOTED(PYGOBJECT_MICRO_VERSION,[$PYGOBJECT_MICRO_VERSION], [PyGObject micro version.])
 
 PKG_CHECK_MODULES(CAJA_PYTHON, [pygobject-3.0 >= $PYGOBJECT_REQUIRED
+                                gmodule-no-export-2.0
                                 libcaja-extension >= $CAJA_REQUIRED])
 
 PYGOBJECT_DATADIR=`$PKG_CONFIG --variable=datadir pygobject-3.0`

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -86,7 +86,7 @@ BUILT_SOURCES = 		\
 	$(HTML_FILES)
 
 reference/builddate.xml: $(REFERENCE_DEPS)
-	$(PYTHON) -c 'import datetime; print datetime.date.today()' > $@
+	$(PYTHON) -c 'import datetime; print (datetime.date.today())' > $@
 
 $(HTML_FILES): $(REFERENCE_DEPS)
 	xsltproc --nonet --xinclude -o $(BUILDDIR)/html/ \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -62,10 +62,6 @@ CSS_FILES = xsl/style.css
 CSSdir = $(HTMLdir)
 CSS_DATA = $(CSS_FILES)
 
-BUILT_SOURCES = 		\
-	reference/builddate.xml	\
-	$(HTML_FILES)
-
 CLEANFILES = 			\
 	caja-python-ref.*	\
 	reference/builddate.xml	\
@@ -84,6 +80,10 @@ REFERENCE_DEPS = 	\
 	$(FIXXREF)
 
 if ENABLE_GTK_DOC
+
+BUILT_SOURCES = 		\
+	reference/builddate.xml	\
+	$(HTML_FILES)
 
 reference/builddate.xml: $(REFERENCE_DEPS)
 	$(PYTHON) -c 'import datetime; print datetime.date.today()' > $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,6 +15,7 @@ libcaja_python_la_CPPFLAGS = \
 	-DDATADIR=\"$(datadir)\" \
 	-DLIBDIR=\"$(libdir)\" \
 	-DPYTHON_VERSION=\"$(PYTHON_VERSION)\" \
+	-DPYTHON_ABIFLAGS=\"$(PYTHON_ABIFLAGS)\" \
 	-DPY_LIB_LOC="\"$(PYTHON_LIB_LOC)\"" \
 	$(CAJA_PYTHON_CFLAGS) \
 	$(AM_CPPFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,5 +24,5 @@ libcaja_python_la_CFLAGS = \
 	$(CAJA_PYTHON_CFLAGS) \
 	$(AM_CFLAGS)
 
-libcaja_python_la_LDFLAGS = -module -avoid-version
+libcaja_python_la_LDFLAGS = -module -avoid-version -Wl,-z,defs
 libcaja_python_la_LIBADD  = $(PYTHON_LIBS) $(CAJA_PYTHON_LIBS)

--- a/src/caja-python-object.c
+++ b/src/caja-python-object.c
@@ -44,6 +44,20 @@
 
 static GObjectClass *parent_class;
 
+#if PY_MAJOR_VERSION >= 3
+#define STRING_CHECK(obj)	PyUnicode_Check(obj)
+#define STRING_FROMSTRING(str)	PyUnicode_FromString(str)
+#define STRING_ASSTRING(obj)	PyUnicode_AsUTF8(obj)
+#define INT_CHECK(obj)		PyLong_Check(obj)
+#define INT_ASLONG(obj)		PyLong_AsLong(obj)
+#else
+#define STRING_CHECK(obj)	PyString_Check(obj)
+#define STRING_FROMSTRING(str)	PyString_FromString(str)
+#define STRING_ASSTRING(obj)	PyString_AsString(obj)
+#define INT_CHECK(obj)		PyInt_Check(obj)
+#define INT_ASLONG(obj)		PyInt(obj)
+#endif
+
 /* These macros assumes the following things:
  *   a METHOD_NAME is defined with is a string
  *   a goto label called beach
@@ -85,7 +99,7 @@ static GObjectClass *parent_class;
 #define HANDLE_LIST(py_ret, type, type_name)                           \
     {                                                                  \
         Py_ssize_t i = 0;                                              \
-    	if (!PySequence_Check(py_ret) || PyString_Check(py_ret))       \
+    	if (!PySequence_Check(py_ret) || STRING_CHECK(py_ret))         \
     	{                                                              \
     		PyErr_SetString(PyExc_TypeError,                           \
     						METHOD_NAME " must return a sequence");    \
@@ -194,7 +208,7 @@ caja_python_object_get_widget (CajaLocationWidgetProvider *provider,
 	CHECK_OBJECT(object);
 	CHECK_METHOD_NAME(object->instance);
 
-	py_uri = PyString_FromString(uri);
+	py_uri = STRING_FROMSTRING(uri);
 
 	py_ret = PyObject_CallMethod(object->instance, METHOD_PREFIX METHOD_NAME,
 								 "(NN)", py_uri,
@@ -425,14 +439,14 @@ caja_python_object_update_file_info (CajaInfoProvider 		*provider,
 	
 	HANDLE_RETVAL(py_ret);
 
-	if (!PyInt_Check(py_ret))
+	if (!INT_CHECK(py_ret))
 	{
 		PyErr_SetString(PyExc_TypeError,
 						METHOD_NAME " must return None or a int");
 		goto beach;
 	}
 
-	ret = PyInt_AsLong(py_ret);
+	ret = INT_ASLONG(py_ret);
 	
  beach:
  	free_pygobject_data(file, NULL);
@@ -522,7 +536,7 @@ caja_python_object_get_type (GTypeModule *module,
 		NULL
 	};
 
-	debug_enter_args("type=%s", PyString_AsString(PyObject_GetAttrString(type, "__name__")));
+	debug_enter_args("type=%s", STRING_ASSTRING(PyObject_GetAttrString(type, "__name__")));
 	info = g_new0 (GTypeInfo, 1);
 	
 	info->class_size = sizeof (CajaPythonObjectClass);
@@ -534,7 +548,7 @@ caja_python_object_get_type (GTypeModule *module,
 	Py_INCREF(type);
 
 	type_name = g_strdup_printf("%s+CajaPython",
-								PyString_AsString(PyObject_GetAttrString(type, "__name__")));
+								STRING_ASSTRING(PyObject_GetAttrString(type, "__name__")));
 		
 	gtype = g_type_module_register_type (module, 
 										 G_TYPE_OBJECT,

--- a/src/caja-python-object.c
+++ b/src/caja-python-object.c
@@ -55,7 +55,7 @@ static GObjectClass *parent_class;
 #define STRING_FROMSTRING(str)	PyString_FromString(str)
 #define STRING_ASSTRING(obj)	PyString_AsString(obj)
 #define INT_CHECK(obj)		PyInt_Check(obj)
-#define INT_ASLONG(obj)		PyInt(obj)
+#define INT_ASLONG(obj)		PyInt_AsLong(obj)
 #endif
 
 /* These macros assumes the following things:

--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -31,6 +31,12 @@
 
 #include <libcaja-extension/caja-extension-types.h>
 
+#if PY_MAJOR_VERSION >= 3
+#define STRING_FROMSTRING(str)	PyUnicode_FromString(str)
+#else
+#define STRING_FROMSTRING(str)	PyString_FromString(str)
+#endif
+
 static const GDebugKey caja_python_debug_keys[] = {
 	{"misc", CAJA_PYTHON_DEBUG_MISC},
 };
@@ -145,7 +151,7 @@ caja_python_load_dir (GTypeModule *module,
 				
 				/* sys.path.insert(0, dirname) */
 				sys_path = PySys_GetObject("path");
-				py_path = PyString_FromString(dirname);
+				py_path = STRING_FROMSTRING(dirname);
 				PyList_Insert(sys_path, 0, py_path);
 				Py_DECREF(py_path);
 			}
@@ -159,7 +165,11 @@ caja_python_init_python (void)
 {
 	PyObject *gi, *require_version, *args, *caja;
 	GModule *libpython;
+#if PY_MAJOR_VERSION >= 3
+	wchar_t *argv[] = { L"caja", NULL };
+#else
 	char *argv[] = { "caja", NULL };
+#endif
 
 	if (Py_IsInitialized())
 		return TRUE;

--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -174,8 +174,8 @@ caja_python_init_python (void)
 	if (Py_IsInitialized())
 		return TRUE;
 
-  	debug("g_module_open " PY_LIB_LOC "/libpython" PYTHON_VERSION "." G_MODULE_SUFFIX ".1.0");
-	libpython = g_module_open(PY_LIB_LOC "/libpython" PYTHON_VERSION "." G_MODULE_SUFFIX ".1.0", 0);
+  	debug("g_module_open " PY_LIB_LOC "/libpython" PYTHON_VERSION PYTHON_ABIFLAGS "." G_MODULE_SUFFIX ".1.0");
+	libpython = g_module_open(PY_LIB_LOC "/libpython" PYTHON_VERSION PYTHON_ABIFLAGS "." G_MODULE_SUFFIX ".1.0", 0);
 	if (!libpython)
 		g_warning("g_module_open libpython failed: %s", g_module_error());
 

--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -196,7 +196,7 @@ caja_python_init_python (void)
 	}
 
 	debug("Sanitize the python search path");
-	PyRun_SimpleString("import sys; sys.path = filter(None, sys.path)");
+	PyRun_SimpleString("import sys; sys.path = list(filter(None, sys.path))");
 	if (PyErr_Occurred())
 	{
 		PyErr_Print();


### PR DESCRIPTION
This PR introduces Python 3 compatibility while retaining Python 2 compatibility.
It also features build failures when a symbol cannot be resolved at link time, and allows to `make dist` without building the documentation.
Runs nice here on Fedora 29 x86_64.

Ref: https://github.com/mate-desktop/python-caja/issues/30

Thanks for considering it.