### PR TITLE
Modernize examples

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -8,6 +8,7 @@ examples_DATA =					\
 	location-widget-provider.py \
 	open-terminal.py			\
 	md5sum-property-page.py		\
+	mixed.py					\
 	submenu.py                  \
 	update-file-info-async.py
 

--- a/examples/background-image.py
+++ b/examples/background-image.py
@@ -1,18 +1,37 @@
-from gi.repository import Caja, GObject, Gio
-
 SUPPORTED_FORMATS = 'image/jpeg', 'image/png'
 BACKGROUND_SCHEMA = 'org.mate.background'
-BACKGROUND_KEY = 'picture-uri'
+BACKGROUND_KEY = 'picture-filename'
+
+try:
+    # Python 3.
+    from urllib.parse import unquote, urlparse
+except:
+    # Python 2.
+    from urllib import unquote
+    from urlparse import urlparse
+
+from gi.repository import Caja, GObject, Gio
+
 
 class BackgroundImageExtension(GObject.GObject, Caja.MenuProvider):
     def __init__(self):
         self.bgsettings = Gio.Settings.new(BACKGROUND_SCHEMA)
     
+    def _filepath(self, file):
+        try:
+            file = file.get_uri()
+        except:
+            pass
+        (scheme, netloc, path, parameters, query, fragment) = urlparse(file)
+        if scheme and unquote(scheme) != 'file':
+            return None
+        return unquote(path)
+
     def menu_activate_cb(self, menu, file):
         if file.is_gone():
             return
         
-        self.bgsettings[BACKGROUND_KEY] = file.get_uri()
+        self.bgsettings[BACKGROUND_KEY] = self._filepath(file)
         
     def get_file_items(self, window, files):
         if len(files) != 1:

--- a/examples/block-size-column.py
+++ b/examples/block-size-column.py
@@ -1,5 +1,11 @@
 import os
-import urllib
+
+try:
+    # Python 3.
+    from urllib.parse import unquote
+except:
+    # Python 2.
+    from urllib import unquote
 
 from gi.repository import GObject, Caja
 
@@ -17,6 +23,6 @@ class ColumnExtension(GObject.GObject, Caja.ColumnProvider, Caja.InfoProvider):
         if file.get_uri_scheme() != 'file':
             return
         
-        filename = urllib.unquote(file.get_uri()[7:])
+        filename = unquote(file.get_uri()[7:])
         
         file.add_string_attribute('block_size', str(os.stat(filename).st_blksize))

--- a/examples/md5sum-property-page.py
+++ b/examples/md5sum-property-page.py
@@ -1,5 +1,11 @@
 import hashlib
-import urllib
+
+try:
+    # Python 3.
+    from urllib.parse import unquote
+except:
+    # Python 2.
+    from urllib import unquote
 
 from gi.repository import Caja, Gtk, GObject
 
@@ -18,7 +24,7 @@ class MD5SumPropertyPage(GObject.GObject, Caja.PropertyPageProvider):
         if file.is_directory():
             return
 
-        filename = urllib.unquote(file.get_uri()[7:])
+        filename = unquote(file.get_uri()[7:])
 
         self.property_label = Gtk.Label('MD5Sum')
         self.property_label.show()
@@ -35,7 +41,7 @@ class MD5SumPropertyPage(GObject.GObject, Caja.PropertyPageProvider):
 
         md5sum = hashlib.md5()
         with open(filename,'rb') as f: 
-            for chunk in iter(lambda: f.read(8192), ''): 
+            for chunk in iter(lambda: f.read(8192), b''): 
                 md5sum.update(chunk)
         f.close()       
 

--- a/examples/mixed.py
+++ b/examples/mixed.py
@@ -1,0 +1,134 @@
+# This Python caja extension only consider files/folders with a mixed
+# upper/lower case name. For those, the following is featured:
+# - an emblem on the icon,
+# - contextual menu entry.
+# - a list view "Mixed" column,
+# - a property page,
+# - A top area widget.
+
+import os
+
+try:
+    # Python 3.
+    from urllib.parse import unquote, urlparse
+except:
+    # Python 2.
+    from urllib import unquote
+    from urlparse import urlparse
+
+from gi.repository import Caja, GObject, Gtk
+
+
+class Mixed(GObject.GObject,
+                Caja.InfoProvider,
+                Caja.ColumnProvider,
+                Caja.MenuProvider,
+                Caja.PropertyPageProvider,
+                Caja.LocationWidgetProvider):
+
+    emblem = 'favorite-symbolic.symbolic'       # Use one of the stock emblems.
+
+    # Private methods.
+
+    def _basename(self, uri):
+        try:
+            uri = uri.get_uri()         # In case a CajaFile is given.
+        except:
+            pass
+        (scheme, netloc, path, parameters, query, fragment) = urlparse(uri)
+        return os.path.basename(unquote(path))
+
+    def _file_has_mixed_name(self, cajafile):
+        name = self._basename(cajafile)
+        if name.upper() != name and name.lower() != name:
+            return 'mixed'
+        return ''
+
+    # Caja.InfoProvider implementation.
+
+    def update_file_info(self, cajafile):
+        mixed = self._file_has_mixed_name(cajafile)
+        cajafile.add_string_attribute('mixed', mixed)
+        if mixed:
+            cajafile.add_emblem(self.emblem)
+
+    # Caja.ColumnProvider implementation.
+
+    def get_columns(self):
+        return [
+            Caja.Column(
+                name        = 'Mixed::mixed_column',
+                attribute   = 'mixed',
+                label       = 'Mixed',
+                description = 'Column added by the mixed extension'
+            )
+        ]
+
+    # Caja.MenuProvider implementation.
+
+    def get_file_items(self, window, cajafiles):
+        menuitems = []
+        if len(cajafiles) == 1:
+            for cajafile in cajafiles:
+                mixed = cajafile.get_string_attribute('mixed')
+                if mixed:
+                    filename = self._basename(cajafile)
+                    menuitem = Caja.MenuItem(
+                        name  = 'Mixed::FileMenu',
+                        label = 'Mixed: %s has a mixed case name' % filename,
+                        tip   = '',
+                        icon  = ''
+                    )
+                    menuitems.append(menuitem)
+
+        return menuitems
+
+    def get_background_items(self, window, folder):
+        mixed = self._file_has_mixed_name(folder)
+        if not mixed:
+            return []
+        return [
+            Caja.MenuItem(
+                name  = 'Mixed::BackgroundMenu',
+                label = 'Mixed: you are browsing a directory with a mixed case name',
+                tip   = '',
+                icon  = ''
+            )
+        ]
+
+    # Caja.PropertyPageProvider implementation.
+
+    def get_property_pages(self, cajafiles):
+        pages = []
+        if len(cajafiles) == 1:
+            for cajafile in cajafiles:
+                if self._file_has_mixed_name(cajafile):
+                    page_label = Gtk.Label('Mixed')
+                    page_label.show()
+                    hbox = Gtk.HBox(homogeneous = False, spacing = 4)
+                    hbox.show()
+                    name_label = Gtk.Label(self._basename(cajafile))
+                    name_label.show()
+                    comment_label = Gtk.Label('has a mixed-case name')
+                    comment_label.show()
+                    hbox.pack_start(name_label, False, False, 0)
+                    hbox.pack_start(comment_label, False, False, 0)
+                    pages.append(
+                        Caja.PropertyPage(
+                            name  = 'Mixed::PropertyPage',
+                            label = page_label,
+                            page  = hbox
+                        )
+                    )
+
+        return pages
+
+    # Caja.LocationWidgetProvider implementation.
+
+    def get_widget(self, uri, window):
+        filename = self._basename(uri)
+        if not self._file_has_mixed_name(filename):
+            return None
+        label = Gtk.Label('In mixed-case directory %s' % filename)
+        label.show()
+        return label

--- a/examples/open-terminal.py
+++ b/examples/open-terminal.py
@@ -1,6 +1,12 @@
 # This example is contributed by Martin Enlund
 import os
-import urllib
+
+try:
+    # Python 3.
+    from urllib.parse import unquote
+except:
+    # Python 2.
+    from urllib import unquote
 
 from gi.repository import Caja, GObject, Gio
 
@@ -12,7 +18,7 @@ class OpenTerminalExtension(Caja.MenuProvider, GObject.GObject):
         self.gsettings = Gio.Settings.new(TERMINAL_SCHEMA)
         
     def _open_terminal(self, file):
-        filename = urllib.unquote(file.get_uri()[7:])
+        filename = unquote(file.get_uri()[7:])
         terminal = self.gsettings[TERMINAL_KEY]
 
         os.chdir(filename)

--- a/examples/update-file-info-async.py
+++ b/examples/update-file-info-async.py
@@ -5,10 +5,13 @@ class UpdateFileInfoAsync(GObject.GObject, Caja.InfoProvider):
         pass
     
     def update_file_info_full(self, provider, handle, closure, file):
-        print "update_file_info_full"
+        print('update_file_info_full')
         GLib.timeout_add_seconds(3, self.update_cb, provider, handle, closure)
         return Caja.OperationResult.IN_PROGRESS
         
     def update_cb(self, provider, handle, closure):
-        print "update_cb"
+        print('update_cb')
         Caja.info_provider_update_complete_invoke(closure, provider, handle, Caja.OperationResult.FAILED)
+
+    def cancel_update(self, provider, handle):
+        print('cancel_update')


### PR DESCRIPTION
The example extension scripts need to be in sync with new versions of
referenced foreign packages.
This commit also makes them compatible with Python version 3 (retaining
Python 2 compatibility).
An additional example extension "mixed" is added: it implements all caja
extension features and can also be used as a new extension pattern. See
source header comment for a description.

Ref: https://github.com/mate-desktop/python-caja/pull/34#issuecomment-457257832

Tested successfully with Fedora 27 x86_64 and Fedora 29 x86_64 with update from PR https://github.com/mate-desktop/python-caja/pull/34