### PR TITLE
Add an explicit --with-python= configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,11 @@ GTK_DOC_CHECK(1.9)
 dnl **************************************************
 dnl * Check for Python
 dnl **************************************************
+AC_ARG_WITH([python],
+	    AS_HELP_STRING([--with-python=<python interpreter>],
+			   [Require a specific Python interpreter]),
+	    [test "$withval" -a "$withval" != no -a "$withval" != yes &&
+              PYTHON="$withval"])
 AM_PATH_PYTHON([2.7])
 PKG_CHECK_MODULES([PYTHON], [python-${PYTHON_VERSION}])
 PYTHON_LIB_LOC="`pkg-config python-${PYTHON_VERSION} --variable=libdir`"
@@ -113,6 +118,7 @@ AC_OUTPUT([
 echo
 echo " caja-python $PACKAGE_VERSION"
 echo
-echo "        Caja Prefix: ${prefix}"
-echo "      Documentation: ${enable_gtk_doc}"
+echo "      Caja Prefix:    ${prefix}"
+echo "      Python version: ${PYTHON_VERSION}"
+echo "      Documentation:  ${enable_gtk_doc}"
 echo


### PR DESCRIPTION
This allows specifying a Python interpreter without using the obscure trick
of externally defining PYTHON in environment.

The configure report now also displays the effective Python version.

Ref: https://github.com/mate-desktop/python-caja/pull/34#issuecomment-460283109