### PR TITLE
Examples: remove use of Python 2/3 incompatible urllib/urlparse.

### DIFF
--- a/examples/background-image.py
+++ b/examples/background-image.py
@@ -2,14 +2,6 @@ SUPPORTED_FORMATS = 'image/jpeg', 'image/png'
 BACKGROUND_SCHEMA = 'org.mate.background'
 BACKGROUND_KEY = 'picture-filename'
 
-try:
-    # Python 3.
-    from urllib.parse import unquote, urlparse
-except:
-    # Python 2.
-    from urllib import unquote
-    from urlparse import urlparse
-
 from gi.repository import Caja, GObject, Gio
 
 
@@ -17,21 +9,12 @@ class BackgroundImageExtension(GObject.GObject, Caja.MenuProvider):
     def __init__(self):
         self.bgsettings = Gio.Settings.new(BACKGROUND_SCHEMA)
     
-    def _filepath(self, file):
-        try:
-            file = file.get_uri()
-        except:
-            pass
-        (scheme, netloc, path, parameters, query, fragment) = urlparse(file)
-        if scheme and unquote(scheme) != 'file':
-            return None
-        return unquote(path)
-
     def menu_activate_cb(self, menu, file):
         if file.is_gone():
             return
-        
-        self.bgsettings[BACKGROUND_KEY] = self._filepath(file)
+
+        if file.get_uri_scheme() == 'file':
+            self.bgsettings[BACKGROUND_KEY] = file.get_location().get_path()
         
     def get_file_items(self, window, files):
         if len(files) != 1:
@@ -52,7 +35,7 @@ class BackgroundImageExtension(GObject.GObject, Caja.MenuProvider):
                                  label='Use as background image',
                                  tip='Set the current image as a background image')
         item.connect('activate', self.menu_activate_cb, file)
-        return item,
+        return [item]
 
     def get_background_items(self, window, file):
         return []

--- a/examples/block-size-column.py
+++ b/examples/block-size-column.py
@@ -1,12 +1,5 @@
 import os
 
-try:
-    # Python 3.
-    from urllib.parse import unquote
-except:
-    # Python 2.
-    from urllib import unquote
-
 from gi.repository import GObject, Caja
 
 class ColumnExtension(GObject.GObject, Caja.ColumnProvider, Caja.InfoProvider):
@@ -23,6 +16,6 @@ class ColumnExtension(GObject.GObject, Caja.ColumnProvider, Caja.InfoProvider):
         if file.get_uri_scheme() != 'file':
             return
         
-        filename = unquote(file.get_uri()[7:])
+        filename = file.get_location().get_path()
         
         file.add_string_attribute('block_size', str(os.stat(filename).st_blksize))

--- a/examples/md5sum-property-page.py
+++ b/examples/md5sum-property-page.py
@@ -1,12 +1,5 @@
 import hashlib
 
-try:
-    # Python 3.
-    from urllib.parse import unquote
-except:
-    # Python 2.
-    from urllib import unquote
-
 from gi.repository import Caja, Gtk, GObject
 
 class MD5SumPropertyPage(GObject.GObject, Caja.PropertyPageProvider):
@@ -24,7 +17,7 @@ class MD5SumPropertyPage(GObject.GObject, Caja.PropertyPageProvider):
         if file.is_directory():
             return
 
-        filename = unquote(file.get_uri()[7:])
+        filename = file.get_location().get_path()
 
         self.property_label = Gtk.Label('MD5Sum')
         self.property_label.show()

--- a/examples/mixed.py
+++ b/examples/mixed.py
@@ -8,14 +8,6 @@
 
 import os
 
-try:
-    # Python 3.
-    from urllib.parse import unquote, urlparse
-except:
-    # Python 2.
-    from urllib import unquote
-    from urlparse import urlparse
-
 from gi.repository import Caja, GObject, Gtk
 
 
@@ -30,16 +22,8 @@ class Mixed(GObject.GObject,
 
     # Private methods.
 
-    def _basename(self, uri):
-        try:
-            uri = uri.get_uri()         # In case a CajaFile is given.
-        except:
-            pass
-        (scheme, netloc, path, parameters, query, fragment) = urlparse(uri)
-        return os.path.basename(unquote(path))
-
     def _file_has_mixed_name(self, cajafile):
-        name = self._basename(cajafile)
+        name = cajafile.get_name()
         if name.upper() != name and name.lower() != name:
             return 'mixed'
         return ''
@@ -72,7 +56,7 @@ class Mixed(GObject.GObject,
             for cajafile in cajafiles:
                 mixed = cajafile.get_string_attribute('mixed')
                 if mixed:
-                    filename = self._basename(cajafile)
+                    filename = cajafile.get_name()
                     menuitem = Caja.MenuItem(
                         name  = 'Mixed::FileMenu',
                         label = 'Mixed: %s has a mixed case name' % filename,
@@ -107,7 +91,7 @@ class Mixed(GObject.GObject,
                     page_label.show()
                     hbox = Gtk.HBox(homogeneous = False, spacing = 4)
                     hbox.show()
-                    name_label = Gtk.Label(self._basename(cajafile))
+                    name_label = Gtk.Label(cajafile.get_name())
                     name_label.show()
                     comment_label = Gtk.Label('has a mixed-case name')
                     comment_label.show()
@@ -126,9 +110,9 @@ class Mixed(GObject.GObject,
     # Caja.LocationWidgetProvider implementation.
 
     def get_widget(self, uri, window):
-        filename = self._basename(uri)
-        if not self._file_has_mixed_name(filename):
+        cajafile = Caja.FileInfo.create_for_uri(uri)
+        if not self._file_has_mixed_name(cajafile):
             return None
-        label = Gtk.Label('In mixed-case directory %s' % filename)
+        label = Gtk.Label('In mixed-case directory ' + cajafile.get_name())
         label.show()
         return label

--- a/examples/open-terminal.py
+++ b/examples/open-terminal.py
@@ -1,13 +1,6 @@
 # This example is contributed by Martin Enlund
 import os
 
-try:
-    # Python 3.
-    from urllib.parse import unquote
-except:
-    # Python 2.
-    from urllib import unquote
-
 from gi.repository import Caja, GObject, Gio
 
 TERMINAL_SCHEMA = 'org.mate.applications-terminal'
@@ -18,7 +11,7 @@ class OpenTerminalExtension(Caja.MenuProvider, GObject.GObject):
         self.gsettings = Gio.Settings.new(TERMINAL_SCHEMA)
         
     def _open_terminal(self, file):
-        filename = unquote(file.get_uri()[7:])
+        filename = file.get_location().get_path()
         terminal = self.gsettings[TERMINAL_KEY]
 
         os.chdir(filename)
@@ -42,11 +35,11 @@ class OpenTerminalExtension(Caja.MenuProvider, GObject.GObject):
                                  label='Open Terminal' ,
                                  tip='Open Terminal In %s' % file.get_name())
         item.connect('activate', self.menu_activate_cb, file)
-        return item,
+        return [item]
 
     def get_background_items(self, window, file):
         item = Caja.MenuItem(name='CajaPython::openterminal_item',
                                  label='Open Terminal Here',
                                  tip='Open Terminal In This Directory')
         item.connect('activate', self.menu_background_activate_cb, file)
-        return item,
+        return [item]


### PR DESCRIPTION
This uses Caja.FileInfo.get_location.get_name() as discussed in https://github.com/mate-desktop/python-caja/pull/35#issuecomment-460653591

Other minor changes targetting lisibility are also included.