### PR TITLE
Run fixxref.py with python2

### DIFF
--- a/docs/xsl/fixxref.py
+++ b/docs/xsl/fixxref.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- Mode: Python; py-indent-offset: 4 -*-
 
 import getopt


### PR DESCRIPTION
`fixxref.py` can't be run with python3, explicitly specified using python2.