### PR TITLE
Change url project's website

### DIFF
--- a/libcaja-python.caja-extension.in.in
+++ b/libcaja-python.caja-extension.in.in
@@ -5,4 +5,4 @@ _Description=Allows to use Python extensions
 Author=Perberos <perberos@gmail.com>;Stefano Karapetsas <stefano@karapetsas.com>;Steve Zesch <stevezesch2@gmail.com>;Johan Dahlin <johan@gnome.org>;Dave Camp <dave@ximian.com>;Calvin Gaisford <cgaisford@novell.com>
 Copyright=Copyright (C) 2004-2005 Johan Dahlin
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.