### PR TITLE
drop Python 2 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ GTK_DOC_CHECK(1.9)
 dnl **************************************************
 dnl * Check for Python
 dnl **************************************************
-AM_PATH_PYTHON([2.7])
+AM_PATH_PYTHON([3.6])
 PYTHON_PKG="python-${PYTHON_VERSION}-embed"
 PKG_CHECK_MODULES([PYTHON], [${PYTHON_PKG}],,
 	[

--- a/docs/xsl/fixxref.py
+++ b/docs/xsl/fixxref.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- Mode: Python; py-indent-offset: 4 -*-
 
 import getopt

--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -32,16 +32,6 @@
 
 #include <libcaja-extension/caja-extension-types.h>
 
-#if PY_MAJOR_VERSION >= 3
-#define STRING_FROMSTRING(str)	PyUnicode_FromString(str)
-#define INT_FROMSSIZE_T(val)    PyLong_FromSsize_t(val)
-#define INT_ASSSIZE_T(obj)      PyLong_AsSsize_t(obj)
-#else
-#define STRING_FROMSTRING(str)	PyString_FromString(str)
-#define INT_FROMSSIZE_T(val)    PyInt_FromSsize_t(val)
-#define INT_ASSSIZE_T(obj)      PyInt_AsSsize_t(obj)
-#endif
-
 static const GDebugKey caja_python_debug_keys[] = {
 	{"misc", CAJA_PYTHON_DEBUG_MISC},
 };
@@ -58,13 +48,13 @@ static GList *all_pyfiles = NULL;
 static PyObject *
 caja_operationhandle_get_handle(PyGBoxed *self, void *closure)
 {
-	return INT_FROMSSIZE_T((Py_ssize_t) (size_t) self->boxed);
+	return PyLong_FromSsize_t((Py_ssize_t) (size_t) self->boxed);
 }
 
 static int
 caja_operationhandle_set_handle(PyGBoxed *self, PyObject *value, void *closure)
 {
-	Py_ssize_t val = INT_ASSSIZE_T(value);
+	Py_ssize_t val = PyLong_AsSsize_t(value);
 
 	if (!PyErr_Occurred()) {
 		if (val) {
@@ -187,7 +177,7 @@ caja_python_load_dir (GTypeModule *module,
 
 				/* sys.path.insert(0, dirname) */
 				sys_path = PySys_GetObject("path");
-				py_path = STRING_FROMSTRING(dirname);
+				py_path = PyUnicode_FromString(dirname);
 				PyList_Insert(sys_path, 0, py_path);
 				Py_DECREF(py_path);
 			}
@@ -201,11 +191,7 @@ caja_python_init_python (void)
 {
 	PyObject *gi, *require_version, *args, *caja, *descr;
 	GModule *libpython;
-#if PY_MAJOR_VERSION >= 3
 	wchar_t *argv[] = { L"caja", NULL };
-#else
-	char *argv[] = { "caja", NULL };
-#endif
 
 	if (Py_IsInitialized())
 		return TRUE;


### PR DESCRIPTION
I've tested this with extensions like caja-admin, caja-mediainfo, caja-rename. In Debian, the patched versions of these extensions can be downloaded from Experimental repo (thanks to @sunweaver for porting).