### PR TITLE
caja-python: Fix memory leak reported by scan-build

### DIFF
--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -172,6 +172,7 @@ caja_python_load_dir (GTypeModule *module,
 				{
 					g_warning("caja_python_init_python failed");
 					g_dir_close(dir);
+					g_free(modulename);
 					break;
 				}
 
@@ -182,6 +183,7 @@ caja_python_load_dir (GTypeModule *module,
 				Py_DECREF(py_path);
 			}
 			caja_python_load_file(module, modulename);
+			g_free(modulename);
 		}
 	}
 }


### PR DESCRIPTION
Test: show file md5sum on caja.
```
$ mkdir -p ~/.local/share/caja-python/extensions/
$ cp examples/md5sum-property-page.py ~/.local/share/caja-python/extensions/
$ echo "hello world!" > hello.txt
$ md5sum hello.txt 
c897d1410af8f2c74fba11b1db511e9e  hello.txt
```

![Screenshot at 2020-04-10 12-47-12](https://user-images.githubusercontent.com/10171411/78985631-93b1cc80-7b29-11ea-82f3-a3662245a978.png)
