### PR TITLE
caja-python-object.c: Remove the extra reference on the PyObject file wrappers when adding them to the python list.

### DIFF
--- a/src/caja-python-object.c
+++ b/src/caja-python-object.c
@@ -69,7 +69,9 @@ static GObjectClass *parent_class;
         py_files = PyList_New(0);                                      \
 		for (l = files; l; l = l->next)                                \
 		{                                                              \
-			PyList_Append(py_files, pygobject_new((GObject*)l->data)); \
+			PyObject *item = pygobject_new ((GObject *)l->data);       \
+			PyList_Append(py_files, item);                             \
+			Py_DECREF (item);                                          \
 		}                                                              \
 	}
 


### PR DESCRIPTION
PyObjects start with a refcount of 1. Adding them to a PyList adds
a second - which gets removes during the list's destruction. The
additional ref was keeping its associated CajaFile from ever being
finalized.

Steps to reproduce problem:
1) Install python-caja and some python MenuProvider extension.
2) Create a folder with a couple of image files inside. Be sure to
   allow thumbs to generate.
3) Enter the folder, select one or more files (so menus are
   generated). De-select and leave the folder (but do not close
   caja). If you were to watch for the files' finalize to run,
   you'd notice it does not.
4) touch or otherwise modify one of the image files from a terminal
5) Re-enter the folder in caja.
6) See that loading runs forever, modified file(s) never
   display. Note: even if you only modify one file, it could cause
   all of the files to fail to load, depending on their order during
   enumeration.

When no more views are displaying a file, that file should be finalized.
When it's not it ends up in an undefined state, as it has no monitors
flag it as needing to be updated