### PR TITLE
build: show configure summary using a pretty format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,11 +115,14 @@ AC_OUTPUT([
   po/Makefile.in
 ])
 
-echo
-echo " caja-python $PACKAGE_VERSION"
-echo
-echo "      Caja Prefix:             ${prefix}"
-echo "      Python version:          ${PYTHON_VERSION}"
-echo "      Python library location: ${PYTHON_LIB_LOC}"
-echo "      Documentation:           ${enable_gtk_doc}"
-echo
+echo "
+Configure summary:
+
+    ${PACKAGE_STRING}
+    `echo $PACKAGE_STRING | sed "s/./=/g"`
+
+    Caja Prefix .................: ${prefix}
+    Python version ..............: ${PYTHON_VERSION}
+    Python library location .....: ${PYTHON_LIB_LOC}
+    Documentation ...............: ${enable_gtk_doc}
+"


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>

Configure summary:

    python-caja 1.24.0
    ==================

    Caja Prefix .................: /usr
    Python version ..............: 3.9
    Python library location .....: /usr/lib64
    Documentation ...............: no

Now type `make' to compile python-caja
```