### PR TITLE
Python 3.13 removes PySys_SetArgv(): set sys.argv in Python language.

### DIFF
--- a/src/caja-python.c
+++ b/src/caja-python.c
@@ -191,7 +191,6 @@ caja_python_init_python (void)
 {
 	PyObject *gi, *require_version, *args, *caja, *descr;
 	GModule *libpython;
-	wchar_t *argv[] = { L"caja", NULL };
 
 	if (Py_IsInitialized())
 		return TRUE;
@@ -209,16 +208,10 @@ caja_python_init_python (void)
 		return FALSE;
 	}
 
-	debug("PySys_SetArgv");
-	PySys_SetArgv(1, argv);
-	if (PyErr_Occurred())
-	{
-		PyErr_Print();
-		return FALSE;
-	}
-
-	debug("Sanitize the python search path");
-	PyRun_SimpleString("import sys; sys.path = list(filter(None, sys.path))");
+	debug("Sanitize the python search path and set sys.argv");
+	PyRun_SimpleString("import sys; "
+			   "sys.path = list(filter(None, sys.path)); "
+			   "sys.argv = ['caja']");
 	if (PyErr_Occurred())
 	{
 		PyErr_Print();


### PR DESCRIPTION
Thanks for considering it!